### PR TITLE
Fix bug in DamerauLevenshtein transposition logic

### DIFF
--- a/lib/rubyfish/damerau_levenshtein.rb
+++ b/lib/rubyfish/damerau_levenshtein.rb
@@ -38,7 +38,7 @@ module RubyFish::DamerauLevenshtein
 
         d_now = [d1, d2, d3].min
 
-        if allow_swaps && i > 2 && j > 2 && as[i - 1] == bs[j - 2] && as[i - 2] == bs[j - 1]
+        if allow_swaps && i > 1 && j > 1 && as[i - 1] == bs[j - 2] && as[i - 2] == bs[j - 1]
           d1 = dist[k - 2][j - 2] + cost
           d_now = [d_now, d1].min;
         end

--- a/spec/damerau_levenshtein_spec.rb
+++ b/spec/damerau_levenshtein_spec.rb
@@ -14,7 +14,8 @@ describe RubyFish::DamerauLevenshtein do
       ["", "", 0],
       ["abc", "", 3],
       ["bc", "abc", 1],
-      ["abc", "acb", 1]
+      ["abc", "acb", 1],
+      ["abc", "bac", 1]
     ])
   end
 

--- a/spec/levenshtein_spec.rb
+++ b/spec/levenshtein_spec.rb
@@ -16,7 +16,9 @@ describe RubyFish::Levenshtein do
       ["abc", "", 3],
       ["bc", "abc", 1],
       ["kitten", "sitting", 3],
-      ["Saturday", "Sunday", 3]
+      ["Saturday", "Sunday", 3],
+      ["abc", "acb", 2],
+      ["abc", "bac", 2]
     ])
   end
 


### PR DESCRIPTION
It appears that there was an error when the pseudocode at the referenced Wikipedia page was translated given Ruby's zero-based string indexing; we're supposed to start checking for transpositions once we're in the second iteration of the loop, but the original port starting checking in the third iteration. This caused incorrect distances to be reported for strings that had transpositions for their first two characters.
